### PR TITLE
Add a command line interface via a Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/src/lib.s
+/src/stst
+/src/stst.out
+/src/stst.s
+/src/stst.tmp

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,34 @@
+# Generate the testable executable inc
+#
+# -m32 forces to compile for 32bit target, this prevents accidental surprises.
+#
+# `-g3 -ggdb3` generates as much debug symbols as possible, notably the latter
+# allows the use of macros in gdb prompt. As of now, only GCC seems to support
+# this option.
+#
+# Omitting the frame pointer with `-fomit-frame-pointer` removes the standard
+# function preamble and post when not needed. This makes the assembly slightly
+# easier to read and harder to debug.
+#
+# `-fno-asynchronous-unwind-tables` gets rid of all the '.cfi' directives from
+# the generated asm.
+
+lib.s: tests-driver.scm compiler.scm lib.scm
+	echo '(compile-lib)' | scheme compiler.scm --quiet
+
+stst: startup.c lib.s stst.s
+	gcc	-m32 \
+		-Wall \
+		-g3 -ggdb3 \
+		-fomit-frame-pointer \
+		-fno-asynchronous-unwind-tables \
+		-O0 startup.c lib.s stst.s \
+		-o stst
+
+.PHONY: test
+test: lib.s
+	echo '(test-all)' | scheme compiler.scm --quiet
+
+.PHONY: clean
+clean:
+	rm -f stst.s lib.s stst stst.out

--- a/src/README.md
+++ b/src/README.md
@@ -13,6 +13,11 @@ Quick instructions to run all tests
       > (compile-lib)     ;; just once
       > (test-all)        ;; run all the tests
 
+or just
+
+    $ make test
+
+
 Full original instructions
 --------------------------
 

--- a/src/tests-driver.scm
+++ b/src/tests-driver.scm
@@ -1,16 +1,6 @@
-(define all-tests '())
+;; Test runner for the incremental compiler
 
-(define (compile-program x)
-  (emit-program x))        ;; implemented by compiler.scm
 (define (emit-library) #f) ;; (optionally) implemented by compiler.scm
-
-(define-syntax add-tests-with-string-output
-  (syntax-rules (=>)
-    [(_ test-name [expr => output-string] ...)
-     (set! all-tests
-        (cons 
-           '(test-name [expr string  output-string] ...)
-            all-tests))]))
 
 (define (build)
   (unless (zero? (system (format "gcc -m32 -Wall -o stst ~a ~a stst.s"
@@ -20,12 +10,41 @@
 
 (define (execute)
   (unless (zero? (system "./stst > stst.out"))
-    (error 'make "produced program exited abnormally")))
+    (error 'make "Produced program exited abnormally")))
 
+(define compile-port
+  (make-parameter
+   (current-output-port)
+   (lambda (p)
+     (unless (output-port? p)
+       (error 'compile-port (format "not an output port ~s" p)))
+     p)))
 
-(define (build-program expr)
-   (run-compile expr)
-   (build))
+(define (emit . args)
+  (apply fprintf (compile-port) args)
+  (newline (compile-port)))
+
+(define runtime-file
+  (make-parameter
+   "startup.c"
+   (lambda (fname)
+     (unless (string? fname)
+       (error 'runtime-file (format "not a string ~s" fname)))
+     fname)))
+
+(define lib-file
+  (make-parameter
+   "lib.s"
+   (lambda (fname)
+     (unless (string? fname)
+       (error 'lib-file (format "not a string ~s" fname)))
+     fname)))
+
+(define (compile-lib)
+  (let ([p (open-output-file (lib-file) 'replace)])
+    (parameterize ([compile-port p])
+      (emit-library))
+    (close-output-port p)))
 
 (define (get-string)
   (with-output-to-string
@@ -38,31 +57,52 @@
                [(eof-object? c) (void)]
                [else (display c) (f)]))))))))
 
+;; Just like emit-program, but send generated asm to outfile
+(define (compile-program expr)
+  (let ([p (open-output-file "stst.s" 'replace)])
+    (parameterize ([compile-port p])
+      (emit-program expr))
+    (close-output-port p)))
+
+;; Compile and run a single expression, great for interactive devel
+(define (run expr)
+  (compile-program expr)
+  (build)
+  (execute)
+  (get-string))
+
+(define all-tests '())
+
+(define-syntax add-tests-with-string-output
+  (syntax-rules (=>)
+    [(_ test-name [expr => output-string]            ...)
+     (set! all-tests
+           (cons
+            '(test-name [expr string  output-string] ...)
+            all-tests))]))
+
 (define (test-with-string-output test-id expr expected-output)
-   (run-compile expr)
-   (build)
-   (execute)
-   (unless (string=? expected-output (get-string))
-     (error 'test (format "output mismatch for test ~s, expected ~s, got ~s"
-        test-id expected-output (get-string)))))
+  (unless (string=? expected-output (run expr))
+    (error 'test (format "Output mismatch for test ~s, expected ~s, got ~s"
+                         test-id expected-output (get-string)))))
 
 (define (test-one test-id test)
   (let ([expr (car test)]
         [type (cadr test)]
         [out  (caddr test)])
-    (printf "test ~s:~s ..." test-id expr)
+    (printf "Test ~s:~s ..." test-id expr)
     (flush-output-port)
     (case type
      [(string) (test-with-string-output test-id expr out)]
      [else (error 'test (format "invalid test type ~s" type))])
     (printf " ok\n")))
- 
+
 (define (test-all)
   (let f ([i 0] [ls (reverse all-tests)])
     (if (null? ls)
-        (printf "passed all ~s tests\n" i)
+        (printf "Passed all ~s tests\n" i)
         (let ([x (car ls)] [ls (cdr ls)])
-          (let* ([test-name (car x)] 
+          (let* ([test-name (car x)]
                  [tests (cdr x)]
                  [n (length tests)])
             (printf "Performing ~a tests ...\n" test-name)
@@ -72,76 +112,3 @@
                 [else
                  (test-one i (car tests))
                  (g (add1 i) (cdr tests))])))))))
-
-
-(define input-filter 
-  (make-parameter (lambda (x) x)
-    (lambda (x)
-      (unless (procedure? x)
-        (error 'input-filter (format "not a procedure ~s" x)))
-      x)))
-
-(define runtime-file 
-  (make-parameter
-    "startup.c"
-    (lambda (fname)
-      (unless (string? fname)
-        (error 'runtime-file (format "not a string ~s" fname)))
-      fname)))
-
-(define lib-file 
-  (make-parameter
-    "lib.s"
-    (lambda (fname)
-      (unless (string? fname)
-        (error 'runtime-file (format "not a string ~s" fname)))
-      fname)))
-
-(define compile-port
-  (make-parameter
-    (current-output-port)
-    (lambda (p)
-       (unless (output-port? p) 
-         (error 'compile-port (format "not an output port ~s" p)))
-       p)))
-
-(define show-compiler-output (make-parameter #f))
-
-(define (run-compile expr)
-  (let ([p (open-output-file "stst.s" 'replace)])
-    (parameterize ([compile-port p])
-       (compile-program expr))
-    (close-output-port p)))
-
-(define (execute)
-  (unless (fxzero? (system "./stst > stst.out"))
-    (error 'execute "produced program exited abnormally")))
-
-(define (get-string)
-  (with-output-to-string
-    (lambda ()
-      (with-input-from-file "stst.out"
-        (lambda ()
-          (let f ()
-            (let ([c (read-char)])
-              (cond
-               [(eof-object? c) (void)]
-               [else (display c) (f)]))))))))
-
-(define (test-with-string-output test-id expr expected-output)
-   (run-compile expr)
-   (build)
-   (execute)
-   (unless (string=? expected-output (get-string))
-     (error 'test (format "output mismatch for test ~s, expected ~s, got ~s"
-        test-id expected-output (get-string)))))
-
-(define (emit . args)
-  (apply fprintf (compile-port) args)
-  (newline (compile-port)))
-
-(define (compile-lib)
-  (let ([p (open-output-file (lib-file) 'replace)])
-    (parameterize ([compile-port p])
-      (emit-library))
-    (close-output-port p)))

--- a/src/tests-driver.scm
+++ b/src/tests-driver.scm
@@ -3,10 +3,8 @@
 (define (emit-library) #f) ;; (optionally) implemented by compiler.scm
 
 (define (build)
-  (unless (zero? (system (format "gcc -m32 -Wall -o stst ~a ~a stst.s"
-                                 (runtime-file)
-                                 (lib-file))))
-    (error 'make "could not build target")))
+  (unless (zero? (system "make stst --quiet"))
+    (error 'make "Could not build target")))
 
 (define (execute)
   (unless (zero? (system "./stst > stst.out"))


### PR DESCRIPTION
This PR depends on #1, I could rebase this after that lands with just one patch instead of 2. 

- Its convenient to run `make test` for example.
- Documentation for compiler flags
