### PR TITLE
Fix Dockerfile to build with gcc8 and current debian:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,18 @@ RUN apt-get update && apt-get install -y \
     gcc-multilib \
     libncurses5-dev \
     libx11-dev \
+    uuid-dev \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Install chez from source
 RUN cd /tmp \
-    && wget -q https://github.com/cisco/ChezScheme/releases/download/v9.5/csv9.5.tar.gz \
-    && tar -xf csv9.5.tar.gz \
-    && cd csv9.5 \
+    && wget -q https://github.com/cisco/ChezScheme/releases/download/v9.5.2/csv9.5.2.tar.gz \
+    && tar -xf csv9.5.2.tar.gz \
+    && cd csv9.5.2 \
     && ./configure \
     && make install \
     && cd - \
-    && rm -rf csv9.5.tar.gz csv9.5
+    && rm -rf csv9.5.2.tar.gz csv9.5.2
 
 ADD . /inc


### PR DESCRIPTION
Before this change the build of Chez Scheme would fail with gcc8 due to `snprintf` calls. See here: https://github.com/cisco/ChezScheme/pull/299

After fixing that, it would fail with `uuid/uuid.h: No such file or directory` which is fixed by installing the `uuid-dev` library.

---

The `make test` itself still fails, though, but I that's unrelated to the Dockerfile I think:

```
$ docker build -t inc . && docker run -it inc bash -c 'cd /inc/src && make test'
[...]
Test 92:(apply vector 1 2 3 4 5 6 7 8 ()) ... Ok.
Performing string-set! errors tests ...
Test 93:(let ((t 1)) (and (begin (set! t (fxadd1 t)) t) t)) ... Ok.
Test 94:(let ((f (if (boolean? (lambda () 12)) (lambda () 13) (lambda () 14)))) (f)) ... Ok.
Test 95:(let ((f 12)) (let ((g (lambda () f))) (g))) ... Ok.
Test 96:(fx< 1 2) ... Ok.
Test 97:(let ((f (lambda (x y) (fx< x y)))) (f 10 10)) ... Ok.
Test 98:(fx< 10 10) ... Ok.
Test 99:(fx< 10 2) ... Ok.
Test 100:(fx<= 1 2) ... Ok.
Test 101:(fx<= 10 10) ... Ok.
Test 102:(fx<= 10 2) ... Ok.
Test 103:(let ((x 12)) (string-set! x 0 #\a)) ...Exception
Segmentation fault

Exception in make: Produced program exited abnormally.
```